### PR TITLE
Fix nosetests incompatible with Py3.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,18 @@ First, install the package in development mode:
 python setup.py develop
 ```
 
-To run tests, use nose (`pip install nose`):
+To run tests:
+
+**Linux**
 ```bash
-nosetests
+cd test
+python3 -m unittest
+```
+
+**Windows**
+```commandline
+cd test
+python -m unittest
 ```
 
 # License


### PR DESCRIPTION
nosetests import collections.Callable which is broken from Python 3.3+ as it is moved into abc as collections.abc.Callable

This change breaks nosetests for Py3.3+ 

https://stackoverflow.com/questions/7438313/pushing-to-git-returning-error-code-403-fatal-http-request-failed/