### PR TITLE
Account params optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,48 @@
 
 A Python library for development of applications that are using NEAR platform.
 
+# Installation
+
+```bash
+pip install near-api-py
+```
+
+# Usage example
+
+## Send money
+
+```python
+near_provider = near_api.providers.JsonProvider("https://rpc.testnet.near.org")
+
+sender_key_pair = near_api.signer.KeyPair("ed25519:[SENDER_PRIVATE_KEY]")
+sender_signer = near_api.signer.Signer("sender.testnet", sender_key_pair)
+sender_account = near_api.account.Account(near_provider, sender_signer)
+
+out = sender_account.send_money("vsab.testnet", 1000)
+
+print(out)
+```
+
+
+## Smart contract call method
+
+```python
+contract_id = "contract.testnet"
+signer_id = "signer.testnet"
+signer_key = "ed25519:[SIGNER_SECRET_KEY]"
+args = {"counter": 1, "action": "increase"}
+
+near_provider = near_api.providers.JsonProvider("https://rpc.testnet.near.org")
+key_pair = near_api.signer.KeyPair(signer_key)
+signer = near_api.signer.Signer(signer_id, key_pair)
+account = near_api.account.Account(near_provider, signer)
+
+out = account.function_call(contract_id, "counter_set", args)
+
+print(out)
+```
+
+
 # Contribution
 
 First, install the package in development mode:

--- a/near_api/account.py
+++ b/near_api/account.py
@@ -79,7 +79,7 @@ class Account(object):
             self,
             contract_id: str,
             method_name: str,
-            args: bytes,
+            args: dict,
             gas: int = DEFAULT_ATTACHED_GAS,
             amount: int = 0
     ) -> dict:
@@ -139,7 +139,7 @@ class Account(object):
                   ] + ([transactions.create_full_access_key_action(public_key)] if public_key is not None else [])
         return self._sign_and_submit_tx(contract_id, actions)
 
-    def view_function(self, contract_id: str, method_name: str, args: bytes) -> dict:
+    def view_function(self, contract_id: str, method_name: str, args: Optional[dict] = None) -> dict:
         """NEAR view method."""
         result = self._provider.view_call(contract_id, method_name, json.dumps(args).encode('utf8'))
         if "error" in result:

--- a/near_api/account.py
+++ b/near_api/account.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+from typing import Optional
 
 import base58
 
@@ -24,13 +25,13 @@ class Account(object):
             self,
             provider: 'near_api.providers.JsonProvider',
             signer: 'near_api.signer.Signer',
-            account_id: str
+            account_id: Optional[str] = None
     ):
         self._provider = provider
         self._signer = signer
-        self._account_id = account_id
-        self._account: dict = provider.get_account(account_id)
-        self._access_key: dict = provider.get_access_key(account_id, self._signer.key_pair.encoded_public_key())
+        self._account_id = account_id or self._signer.account_id
+        self._account: dict = provider.get_account(self._account_id)
+        self._access_key: dict = provider.get_access_key(self._account_id, self._signer.key_pair.encoded_public_key())
         # print(account_id, self._account, self._access_key)
 
     def _sign_and_submit_tx(self, receiver_id: str, actions: list['transactions.Action']) -> dict:
@@ -94,7 +95,8 @@ class Account(object):
         actions = [
             transactions.create_create_account_action(),
             transactions.create_full_access_key_action(public_key),
-            transactions.create_transfer_action(initial_balance)]
+            transactions.create_transfer_action(initial_balance),
+        ]
         return self._sign_and_submit_tx(account_id, actions)
 
     def delete_account(self, beneficiary_id: str) -> dict:

--- a/test/config.py
+++ b/test/config.py
@@ -12,3 +12,5 @@
 # NODE_URL = "https://rpc.testnet.near.org"
 
 NODE_URL = "https://rpc.ci-testnet.near.org"
+TEST_ACCOUNT = "test.near"
+TEST_KEY_PAIR = "ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw"

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -1,7 +1,7 @@
 import unittest
 
 import near_api
-from config import NODE_URL
+from config import NODE_URL, TEST_ACCOUNT, TEST_KEY_PAIR
 from utils import create_account
 
 
@@ -9,12 +9,10 @@ class AccountTest(unittest.TestCase):
     def setUp(self):
         self.provider = near_api.providers.JsonProvider(NODE_URL)
         self.signer = near_api.signer.Signer(
-            "test.near",
-            near_api.signer.KeyPair(
-                "ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw"
-            )
+            TEST_ACCOUNT,
+            near_api.signer.KeyPair(TEST_KEY_PAIR)
         )
-        self.master_account = near_api.account.Account(self.provider, self.signer, "test.near")
+        self.master_account = near_api.account.Account(self.provider, self.signer)
 
     def test_create_account(self):
         amount = 10 ** 24

--- a/test/test_provider.py
+++ b/test/test_provider.py
@@ -2,7 +2,7 @@ import time
 import unittest
 
 import near_api
-from config import NODE_URL
+from config import NODE_URL, TEST_ACCOUNT, TEST_KEY_PAIR
 from utils import create_account
 
 
@@ -10,28 +10,26 @@ class JsonProviderTest(unittest.TestCase):
     def setUp(self):
         self.provider = near_api.providers.JsonProvider(NODE_URL)
         self.signer = near_api.signer.Signer(
-            "test.near",
-            near_api.signer.KeyPair(
-                "ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw"
-            )
+            TEST_ACCOUNT,
+            near_api.signer.KeyPair(TEST_KEY_PAIR)
         )
-        self.master_account = near_api.account.Account(self.provider, self.signer, "test.near")
+        self.master_account = near_api.account.Account(self.provider, self.signer)
 
     def test_status(self):
         status = self.provider.get_status()
         self.assertIsNotNone(status["chain_id"])
 
     def test_get_account(self):
-        response = self.provider.get_account("test.near")
+        response = self.provider.get_account(TEST_ACCOUNT)
         self.assertEqual(response["code_hash"], "11111111111111111111111111111111")
 
-    def test_get_validators_orderes(self):
+    def test_get_validators_orders(self):
         status = self.provider.get_status()
         latest_block_hash = status['sync_info']['latest_block_hash']
         self.assertEqual(
             self.provider.get_validators_ordered(latest_block_hash)[0]
             ['account_id'],
-            'test.near'
+            TEST_ACCOUNT
         )
 
     def test_get_next_light_client_block(self):

--- a/test/utils.py
+++ b/test/utils.py
@@ -7,5 +7,5 @@ def create_account(master_account, amount=10 ** 24):
     account_id = "testtest-%s.test.near" % int(time.time() * 10_000)
     master_account.create_account(account_id, master_account.signer.public_key, amount)
     signer = near_api.signer.Signer(account_id, master_account.signer.key_pair)
-    account = near_api.account.Account(master_account.provider, signer, account_id)
+    account = near_api.account.Account(master_account.provider, signer)
     return account


### PR DESCRIPTION
**Account** instance param like **account_id** in most cases can be used from signer and not need to specify it explicitly.
Fixed tests.
Fixed old incorrect typehints.
Added to README.md examples and installation manual.
