### PR TITLE
Add GitHub CI to Repo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: CI
+on: push
+jobs:
+  tests:
+    name: NAPy Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install requirements
+        run: pip install tox && pip install .
+      - name: Run tests
+        run: python -m unittest discover test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .env
 .tox
+venv
+.venv
 near_api_py.egg-info
 __pycache__
 .vscode

--- a/near_api/account.py
+++ b/near_api/account.py
@@ -1,6 +1,6 @@
 import itertools
 import json
-from typing import Optional
+from typing import Optional, List
 
 import base58
 
@@ -34,7 +34,7 @@ class Account(object):
         self._access_key: dict = provider.get_access_key(self._account_id, self._signer.key_pair.encoded_public_key())
         # print(account_id, self._account, self._access_key)
 
-    def _sign_and_submit_tx(self, receiver_id: str, actions: list['transactions.Action']) -> dict:
+    def _sign_and_submit_tx(self, receiver_id: str, actions: List['transactions.Action']) -> dict:
         self._access_key['nonce'] += 1
         block_hash = self._provider.get_status()['sync_info']['latest_block_hash']
         block_hash = base58.b58decode(block_hash.encode('utf8'))

--- a/near_api/transactions.py
+++ b/near_api/transactions.py
@@ -1,4 +1,5 @@
 import hashlib
+from typing import List
 
 import near_api
 from near_api.serializer import BinarySerializer
@@ -256,7 +257,7 @@ tx_schema = dict(
 def sign_and_serialize_transaction(
         receiver_id: str,
         nonce: int,
-        actions: list[Action],
+        actions: List[Action],
         block_hash: bytes,
         signer: 'near_api.signer.Signer'
 ) -> bytes:


### PR DESCRIPTION
This PR adds a GitHub Actions CI job for all pushes to all branches in this repo. This also adds typing from the generic `typing` library for backwards compatibility with previous version of Python 3.

The steps of interest of the CI particularly are: 

```yml
      - name: Install Python
        uses: actions/setup-python@v2
        with:
          python-version: '3.7'
      - name: Install requirements
        run: pip install tox && pip install .
      - name: Run tests
        run: python -m unittest discover test
```